### PR TITLE
Top page  background-image  edit

### DIFF
--- a/app/assets/stylesheets/header_footer/footer.scss
+++ b/app/assets/stylesheets/header_footer/footer.scss
@@ -2,11 +2,11 @@
   box-sizing: border-box;
 }
 .appBanner{
-            background-image: url(/assets/material/pict/bg-appBanner-pict.jpg);
-            padding: 100px 40px;
-            position: relative;
-            background-size: cover;
-            background-position: center;    
+  background-image:image-url("material/pict/bg-appBanner-pict.jpg");
+  padding: 100px 40px;
+  position: relative;
+  background-size: cover;
+  background-position: center;    
 &__inner{
   color: #fff;
   text-align: center;

--- a/app/assets/stylesheets/top_section/number1.scss
+++ b/app/assets/stylesheets/top_section/number1.scss
@@ -1,7 +1,7 @@
 .mainVisual{
   width: 100%;
   height: 560px;
-  background-image: url(material/pict/bg-mainVisual-pict_pc.jpg);
+  background-image:image-url("material/pict/bg-mainVisual-pict_pc.jpg");
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;
@@ -194,6 +194,5 @@ margin: 16px 5% 0 0;
 }
 }
 span{
-color: #3CCACE;
-}
-
+  color: #3CCACE;
+  }

--- a/app/assets/stylesheets/top_section/number2.scss
+++ b/app/assets/stylesheets/top_section/number2.scss
@@ -36,8 +36,8 @@
 }
 // ここからセクション2の2ブロック目
 .topKeyFeatures{
-               padding: 60px 100px;
-               background-color: #fff;
+  padding: 60px 100px;
+  background-color: #fff;
 }
 .head{
 font-size: 27px;

--- a/app/assets/stylesheets/top_section/number2.scss
+++ b/app/assets/stylesheets/top_section/number2.scss
@@ -1,6 +1,6 @@
 // 上から二つ目のセクションです
 .topMiddleDl{
-  background-image: url(/assets/material/pict/bg-topMiddleDl-pict.jpg);
+  background-image:image-url("material/pict/bg-topMiddleDl-pict.jpg");
   background-position: bottom right;
   height: 400px;
   background-size: cover;


### PR DESCRIPTION
What
SCSSのback-ground-imageを
background-image: url(matelial/.....)から
background-image: image-url("material/pict/bg-mainVisual-pict_pc.jpeg")の書き方に直した。

書き直した場所
number1, number2, footer 

Why
本番環境でbackground-imageを反映させるため